### PR TITLE
Move downloaded files to BiocFileCache rather than copy

### DIFF
--- a/R/iSEEindexResource-class.R
+++ b/R/iSEEindexResource-class.R
@@ -88,8 +88,7 @@ setMethod("precache", "iSEEindexResource",
 #' Refer to the documentation for each method for more details on the remaining arguments.
 #' 
 #' \itemize{
-#' \item \code{\link{precache}(x, ...)} returns the URI to the resource as-is,
-#' because The \pkg{BiocFileCache} naturally supports the HTTPS protocol.
+#' \item \code{\link{precache}(x, bfc, id, ...)} caches the resource located at the given URI using \pkg{BiocFileCache} and returns the file path to the cached file.
 #' }
 #' 
 #' @author Kevin Rue-Albrecht
@@ -144,8 +143,7 @@ setMethod("precache", "iSEEindexHttpsResource",
 #' Refer to the documentation for each method for more details on the remaining arguments.
 #' 
 #' \itemize{
-#' \item \code{\link{precache}(x, ...)} trims the `localhost://` prefix,
-#' and returns the remainder of the URI as a file path, for use in the \pkg{BiocFileCache}.
+#' \item \code{\link{precache}(x, ...)} trims the `localhost://` prefix, and caches a copy of the resource located at the resulting file path using \pkg{BiocFileCache}, before returning the file path to the cached file.
 #' }
 #' 
 #' @author Kevin Rue-Albrecht
@@ -201,8 +199,9 @@ setMethod("precache", "iSEEindexLocalhostResource",
 #' 
 #' \itemize{
 #' \item \code{\link{precache}(x, ...)} trims the `rcall://` prefix,
-#' evaluates the remainder of the URI as R code,
-#' and returns the resulting file path, for use in the \pkg{BiocFileCache}.
+#' evaluates the remainder of the URI as R code, and caches a copy of the
+#' resource located at the resulting file path using \pkg{BiocFileCache},
+#' before returning the file path to the cached file.
 #' }
 #' 
 #' @author Kevin Rue-Albrecht
@@ -264,8 +263,8 @@ setMethod("precache", "iSEEindexRcallResource",
 #' \item \code{\link{precache}(x, ..., temp_dir = tempdir())} trims the `s3://` prefix,
 #' parses information encoded in the remainder of the URI,
 #' downloads the resource from AWS S3 using that information,
-#' and returns the local file path to the downloaded resource,
-#' for use in the \pkg{BiocFileCache}.
+#' and caches a copy of the resource located at the resulting file path using
+#' \pkg{BiocFileCache}, before returning the file path to the cached file.
 #' }
 #' 
 #' @section Pre-caching:

--- a/R/iSEEindexResource-class.R
+++ b/R/iSEEindexResource-class.R
@@ -317,6 +317,7 @@ setClass("iSEEindexS3Resource", contains="iSEEindexResource")
 setMethod("precache", "iSEEindexS3Resource",
     function(x, bfc, id, ..., temp_dir = tempdir())
 {
+    # nocov start
     # Trim 's3://' from the original URI and pass to paws.storage,
     # which will manage the download.
     # Pass the local filepath to BiocFileCache, which will cache the downloaded file.
@@ -333,4 +334,5 @@ setMethod("precache", "iSEEindexS3Resource",
     stopifnot(file.exists(fpath))
     object_path <- bfcadd(x = bfc, rname = id, fpath = fpath, action = "move", ...)
     return(object_path)
+    # nocov end
 })

--- a/R/iSEEindexResource-class.R
+++ b/R/iSEEindexResource-class.R
@@ -250,7 +250,7 @@ setMethod("precache", "iSEEindexRcallResource",
 #' For instance:
 #' 
 #' ```
-#' s3://your-bucket/your-prefix/index.rds)
+#' s3://bucket/prefix/index.rds
 #' ```
 #' 
 #' @section Slot overview:

--- a/R/iSEEindexResource-class.R
+++ b/R/iSEEindexResource-class.R
@@ -167,7 +167,7 @@ setMethod("precache", "iSEEindexLocalhostResource",
     # which will manage the caching.
     # Use action="copy" to leave the original file untouched.
     fpath <- sub("localhost://", "", x@uri)
-    stopifnot(file.exists(out))
+    stopifnot(file.exists(fpath))
     object_path <- bfcadd(x = bfc, rname = id, fpath = fpath, action = "copy", ...)
     return(object_path)
 })

--- a/R/utils-datasets.R
+++ b/R/utils-datasets.R
@@ -36,8 +36,7 @@
     if (nrow(bfc_result) == 0) {
         # TODO: refactor to a funtion that is also used by .load_initial
         uri_object <- .uri_to_object(uri)
-        bfc_fpath <- precache(uri_object)
-        object_path <- bfcadd(x = bfc, rname = id, fpath = bfc_fpath)
+        object_path <- precache(uri_object, bfc, id)
     } else {
         object_path <- bfc[[bfc_result$rid]]
     }

--- a/R/utils-initial.R
+++ b/R/utils-initial.R
@@ -56,8 +56,7 @@
         # nocov start
         if (nrow(bfc_result) == 0) {
             uri_object <- .uri_to_object(uri)
-            bfc_fpath <- precache(uri_object)
-            script_path <- bfcadd(x = bfc, rname = bfc_config_id, fpath = bfc_fpath)
+            script_path <- precache(uri_object, bfc, id)
         } else {
             script_path <- bfc[[bfc_result$rid]]
         }

--- a/R/utils-initial.R
+++ b/R/utils-initial.R
@@ -56,7 +56,7 @@
         # nocov start
         if (nrow(bfc_result) == 0) {
             uri_object <- .uri_to_object(uri)
-            script_path <- precache(uri_object, bfc, id)
+            script_path <- precache(uri_object, bfc, bfc_config_id)
         } else {
             script_path <- bfc[[bfc_result$rid]]
         }

--- a/man/iSEEindexHttpsResource-class.Rd
+++ b/man/iSEEindexHttpsResource-class.Rd
@@ -20,8 +20,7 @@ In the following code snippets, \code{x} is an instance of a \linkS4class{iSEEin
 Refer to the documentation for each method for more details on the remaining arguments.
 
 \itemize{
-\item \code{\link{precache}(x, ...)} returns the URI to the resource as-is,
-because The \pkg{BiocFileCache} naturally supports the HTTPS protocol.
+\item \code{\link{precache}(x, bfc, id, ...)} caches the resource located at the given URI using \pkg{BiocFileCache} and returns the file path to the cached file.
 }
 }
 

--- a/man/iSEEindexLocalhostResource-class.Rd
+++ b/man/iSEEindexLocalhostResource-class.Rd
@@ -34,8 +34,7 @@ In the following code snippets, \code{x} is an instance of a \linkS4class{iSEEin
 Refer to the documentation for each method for more details on the remaining arguments.
 
 \itemize{
-\item \code{\link{precache}(x, ...)} trims the \verb{localhost://} prefix,
-and returns the remainder of the URI as a file path, for use in the \pkg{BiocFileCache}.
+\item \code{\link{precache}(x, ...)} trims the \verb{localhost://} prefix, and caches a copy of the resource located at the resulting file path using \pkg{BiocFileCache}, before returning the file path to the cached file.
 }
 }
 

--- a/man/iSEEindexRcallResource-class.Rd
+++ b/man/iSEEindexRcallResource-class.Rd
@@ -32,8 +32,9 @@ Refer to the documentation for each method for more details on the remaining arg
 
 \itemize{
 \item \code{\link{precache}(x, ...)} trims the \verb{rcall://} prefix,
-evaluates the remainder of the URI as R code,
-and returns the resulting file path, for use in the \pkg{BiocFileCache}.
+evaluates the remainder of the URI as R code, and caches a copy of the
+resource located at the resulting file path using \pkg{BiocFileCache},
+before returning the file path to the cached file.
 }
 }
 

--- a/man/iSEEindexResource-class.Rd
+++ b/man/iSEEindexResource-class.Rd
@@ -21,7 +21,7 @@ In the following code snippets, \code{x} is an instance of a \linkS4class{iSEEin
 Refer to the documentation for each method for more details on the remaining arguments.
 
 \itemize{
-\item \code{\link{precache}(x, ...)} throws an error, encouraging users to develop a method for derived classes that are not suported yet.
+\item \code{\link{precache}(x, bfc, id, ...)} throws an error, encouraging users to develop a method for derived classes that are not suported yet.
 }
 }
 

--- a/man/iSEEindexResource-generics.Rd
+++ b/man/iSEEindexResource-generics.Rd
@@ -8,11 +8,13 @@
 \description{
 An overview of the generics for downloading and caching resources.
 }
-\section{Defining the parameter interface}{
+\section{Preparing and caching resources}{
 
-\code{precache(x, ...)} potentially downloads a resource from an URI and returns the path to the local file:
+\code{precache(x, bfc, id, ...)} potentially downloads a resource from an URI, caches it, and returns the path to the cached file:
 \itemize{
 \item \code{x}, a character scalar that represents a URI.
+\item \code{bfc}, a \code{\link[=BiocFileCache]{BiocFileCache()}} object..
+\item \code{id}, a data set identifier as a character scalar..
 \item \code{...}, additional arguments passed to and from other methods.
 }
 }

--- a/man/iSEEindexS3Resource-class.Rd
+++ b/man/iSEEindexS3Resource-class.Rd
@@ -36,8 +36,8 @@ Refer to the documentation for each method for more details on the remaining arg
 \item \code{\link{precache}(x, ..., temp_dir = tempdir())} trims the \verb{s3://} prefix,
 parses information encoded in the remainder of the URI,
 downloads the resource from AWS S3 using that information,
-and returns the local file path to the downloaded resource,
-for use in the \pkg{BiocFileCache}.
+and caches a copy of the resource located at the resulting file path using
+\pkg{BiocFileCache}, before returning the file path to the cached file.
 }
 }
 

--- a/man/iSEEindexS3Resource-class.Rd
+++ b/man/iSEEindexS3Resource-class.Rd
@@ -19,7 +19,7 @@ For details about authentication, see section \dQuote{AWS Credentials} below.
 
 For instance:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{s3://your-bucket/your-prefix/index.rds)
+\if{html}{\out{<div class="sourceCode">}}\preformatted{s3://bucket/prefix/index.rds
 }\if{html}{\out{</div>}}
 }
 \section{Slot overview}{

--- a/tests/testthat/test-iSEEindexResources-class.R
+++ b/tests/testthat/test-iSEEindexResources-class.R
@@ -25,9 +25,11 @@ test_that("show(iSEEindexHttpsResource) works", {
 
 test_that("precache(iSEEindexHttpsResource) returns the original URI", {
 
-    out <- new("iSEEindexHttpsResource", uri = "https://zenodo.org/record/7304331/files/ReprocessedAllenData.rds?download=1")
-    expect_identical(precache(out), out@uri)
+    x <- new("iSEEindexHttpsResource", uri = "https://zenodo.org/record/7304331/files/ReprocessedAllenData_config_01.R?download=1")
+    out <- precache(x, bfc, "DUMMY")
+    expect_true(file.exists(out))
 
+    bfcremove(bfc, names(out))
 })
 
 # iSEEindexLocalhostResource ----
@@ -44,8 +46,11 @@ test_that("precache(iSEEindexLocalhostResource) workls", {
     tf <- tempfile()
     file.create(tf)
     
-    out <- new("iSEEindexLocalhostResource", uri = sprintf("localhost://%s", tf))
-    expect_identical(precache(out), tf)
+    x <- new("iSEEindexLocalhostResource", uri = sprintf("localhost://%s", tf))
+    out <- precache(x, bfc, "DUMMY")
+    expect_true(file.exists(out))
+
+    bfcremove(bfc, names(out))
     
     unlink(tf)
 })
@@ -61,6 +66,20 @@ test_that("show(iSEEindexRcallResource) works", {
 
 test_that("precache(iSEEindexRcallResource) workls", {
     
-    out <- new("iSEEindexRcallResource", uri = "rcall://system.file(package='iSEEindex','ReprocessedAllenData_config_01.R')")
-    expect_identical(precache(out), system.file(package='iSEEindex','ReprocessedAllenData_config_01.R'))
+    x <- new("iSEEindexRcallResource", uri = "rcall://system.file(package='iSEEindex','ReprocessedAllenData_config_01.R')")
+    out <- precache(x, bfc, "DUMMY")
+    expect_true(file.exists(out))
+
+    bfcremove(bfc, names(out))
+})
+
+
+
+# iSEEindexRcallResource ----
+
+test_that("show(iSEEindexS3Resource) works", {
+
+    x <- new("iSEEindexS3Resource", uri = "s3://bucket/file.R")
+    expect_output(show(x), "class: iSEEindexS3Resource")
+
 })

--- a/vignettes/resources.Rmd
+++ b/vignettes/resources.Rmd
@@ -176,11 +176,11 @@ Code for creating the vignette
 ```{r createVignette, eval=FALSE}
 ## Create the vignette
 library("rmarkdown")
-system.time(render("iSEEindex.Rmd", "BiocStyle::html_document"))
+system.time(render("resources.Rmd", "BiocStyle::html_document"))
 
 ## Extract the R code
 library("knitr")
-knit("iSEEindex.Rmd", tangle = TRUE)
+knit("resources.Rmd", tangle = TRUE)
 ```
 
 Date the vignette was generated.

--- a/vignettes/resources.Rmd
+++ b/vignettes/resources.Rmd
@@ -176,7 +176,7 @@ s3://bucket/prefix/index.rds
 
 ### Caching
 
-Now, while the scheme `s3` is recognised by the [AWS Command Line Interface][aws-cli], `r Biocpkg("BiocFileCache")` does not know how to deal with it.
+Now, while the scheme `s3` is recognised by the [AWS Command Line Interface][aws-cli], the `r Biocpkg("BiocFileCache")` package does not know how to deal with it.
 
 In this instance, the `precache()` function has the job to parse the URI for information that is passed to the `r BiocStyle::CRANpkg("paws.storage")` package to download the file, which is then cached using `r Biocpkg("BiocFileCache")`.
 

--- a/vignettes/resources.Rmd
+++ b/vignettes/resources.Rmd
@@ -103,7 +103,7 @@ https://zenodo.org/record/7304331/files/ReprocessedAllenData.rds?download=1
 
 The `r Biocpkg("BiocFileCache")` package can perfectly well handle HTTPS.
 
-In this instance, the `precache()` function has no other job than to return the URI _as is_, for the `r Biocpkg("BiocFileCache")` package to use during caching.
+In this instance, the `precache()` function has no other job than to cache the file located at the resulting file URI using `r Biocpkg("BiocFileCache")`.
 
 
 ## iSEEindexLocalhostResource
@@ -127,7 +127,7 @@ localhost://relative/path/to/file
 
 Now, while the `r Biocpkg("BiocFileCache")` package can perfectly well handle local files, it does not know how to deal with the custom scheme `localhost`.
 
-In this instance, the `precache()` function has the only job to remove the `localhost://` prefix from the URI, and return the remainder of the URI, which the `r Biocpkg("BiocFileCache")` package can use for caching.
+In this instance, the `precache()` function has the only job to remove the `localhost://` prefix from the URI, and cache the file located at the resulting file path using `r Biocpkg("BiocFileCache")`.
 
 
 ## iSEEindexRcallResource
@@ -153,7 +153,32 @@ rcall://system.file(package='iSEEindex','ReprocessedAllenData_config_01.R')
 The custom scheme `rcall` is entirely made up for the purpose described here; it is not in any way recognised as a standard scheme by the [Internet Assigned Numbers Authority (IANA)][iana-uri].
 As such, the `r Biocpkg("BiocFileCache")` package cannot possibly know how to handle that custom scheme.
 
-In this instance, the `precache()` function has the job to remove the `rcall://` prefix from the URI, evaluate the remainder of the URI as R code, and return the output of the R code, which should be a `character` scalar representing a valid URI that the `r Biocpkg("BiocFileCache")` package can use for caching.
+In this instance, the `precache()` function has the job to remove the `rcall://` prefix from the URI, evaluate the remainder of the URI as R code, and cache the file located at the resulting file path using `r Biocpkg("BiocFileCache")`.
+
+
+## iSEEindexS3Resource
+
+### Structure
+
+This type of resource is documented in `help("iSEEindexS3Resource-class")`.
+
+Briefly, this class is used to represent files that are accessible directly from [Amazon S3][amazon-s3].
+
+The URI must use the custom scheme "s3", followed by the S3 URI to the file.
+
+This custom scheme was created mainly to dynamically fetch the example files distributed and installed with the package.
+
+Example:
+
+```bash
+s3://bucket/prefix/index.rds
+```
+
+### Caching
+
+Now, while the scheme `s3` is recognised by the [AWS Command Line Interface][aws-cli], `r Biocpkg("BiocFileCache")` does not know how to deal with it.
+
+In this instance, the `precache()` function has the job to parse the URI for information that is passed to the `r BiocStyle::CRANpkg("paws.storage")` package to download the file, which is then cached using `r Biocpkg("BiocFileCache")`.
 
 
 # Reproducibility
@@ -225,3 +250,5 @@ PrintBibliography(bib, .opts = list(hyperlink = "to.doc", style = "html"))
 
 [scheme-wikipedia]: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax
 [iana-uri]: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+[amazon-s3]: https://aws.amazon.com/s3/
+[aws-cli]: https://aws.amazon.com/cli/

--- a/vignettes/resources.Rmd
+++ b/vignettes/resources.Rmd
@@ -103,7 +103,7 @@ https://zenodo.org/record/7304331/files/ReprocessedAllenData.rds?download=1
 
 The `r Biocpkg("BiocFileCache")` package can perfectly well handle HTTPS.
 
-In this instance, the `precache()` function has no other job than to cache the file located at the resulting file URI using `r Biocpkg("BiocFileCache")`.
+In this instance, the `precache()` function has no other job than to cache the file located at the given URI using `r Biocpkg("BiocFileCache")`.
 
 
 ## iSEEindexLocalhostResource


### PR DESCRIPTION
Fixes #16 

Specifically applies to files downloaded form AWS S3 using custom code.
Those downloaded files are _moved_ to the cache, saving time and disk space.

Does not apply to files downloaded from HTTPS links, as those are naturally managed by BiocFileCache, which stores the downloaded copy directly in the cache.